### PR TITLE
Changed get news item property based on change in API

### DIFF
--- a/src/hooks/useNews.js
+++ b/src/hooks/useNews.js
@@ -9,8 +9,8 @@ const useNews = props => {
 
   useEffect(() => {
     GetNews()
-      .then(response => {
-        setNewsItems(response);
+      .then(({ records }) => {
+        setNewsItems(records);
       })
       .catch(() => {
         setHasError(true);


### PR DESCRIPTION
The api has changed and and new stories are not found in the root of the api response.

it looks like this now

```js
{
  "metaData": { },
  "records": [{}, {}, {}] // newstories are heere
}
```