### PR TITLE
added html parser to news room titles and body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10655,6 +10655,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
+    "react-html-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-html-parser/-/react-html-parser-2.0.2.tgz",
+      "integrity": "sha512-XeerLwCVjTs3njZcgCOeDUqLgNIt/t+6Jgi5/qPsO/krUWl76kWKXMeVs2LhY2gwM6X378DkhLjur0zUQdpz0g==",
+      "requires": {
+        "htmlparser2": "^3.9.0"
+      }
+    },
     "react-is": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "^16.12.0",
     "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.12.0",
+    "react-html-parser": "^2.0.2",
     "react-scripts": "^3.4.3"
   },
   "scripts": {

--- a/src/components/NewsRoomCard.jsx
+++ b/src/components/NewsRoomCard.jsx
@@ -4,7 +4,7 @@ import {
   CardContent,
   CardFooter,
 } from "@baltimorecounty/dotgov-components";
-
+import ReactHtmlParser from "react-html-parser";
 import React from "react";
 
 const NewsRoomCard = (props) => {
@@ -23,7 +23,7 @@ const NewsRoomCard = (props) => {
   return (
     <Card className="text-left">
       <h2>
-        <a href={url}>{title}</a>
+        <a href={url}>{ReactHtmlParser(title)}</a>
       </h2>
       <CardContent>
         <div className="row">
@@ -32,7 +32,7 @@ const NewsRoomCard = (props) => {
               <span>{articleDate}</span>
               <span>{author || "Baltimore County"}</span>
             </p>
-            <p>{articleSummary}</p>
+            <p>{ReactHtmlParser(articleSummary)}</p>
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
To fix html escaped special characters we needed to add the html parser to the titles and body of the cards.